### PR TITLE
Fix BiocCheck and downsample dataset in vignette 

### DIFF
--- a/.github/workflows/build_check_deploy.yml
+++ b/.github/workflows/build_check_deploy.yml
@@ -47,16 +47,16 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual"), error_on = "error", check_dir = "check")
-        shell: Rscript {0}
-
       - name: BiocCheck
         run: |
           BiocManager::install("BiocCheck")
           BiocCheck::BiocCheck(".")
+        shell: Rscript {0}
+
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual"), error_on = "error", check_dir = "check")
         shell: Rscript {0}
 
       - name: Publish to Registry

--- a/.github/workflows/build_check_deploy.yml
+++ b/.github/workflows/build_check_deploy.yml
@@ -47,13 +47,17 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: BiocCheck
+      - name: Install BiocCheck
         run: |
           BiocManager::install("BiocCheck")
+        shell: Rscript {0}
+
+      - name: BiocCheck
+        run: |
           BiocCheck::BiocCheck(".")
         shell: Rscript {0}
 
-      - name: Check
+      - name: R CMD check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual"), error_on = "error", check_dir = "check")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "ke
     person("Aaron", "Lun", role="aut", email="infinite.monkeys.with.keyboards@gmail.com", comment = c(ORCID = '0000-0002-3564-4813')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')))
 Description: Bioconductor-friendly wrappers for RNA velocity calculations in single-cell RNA-seq data.
+    The basilisk package is used to manage Conda environments.
 Depends:
     SummarizedExperiment
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Suggests:
     scRNAseq,
     ggplot2,
     Rtsne
-Remotes: theislab/zellkonverter
 StagedInstall: no
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Depends:
     SummarizedExperiment
 Imports:
     methods,
+    stats,
     Matrix,
     BiocGenerics,
     reticulate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,12 @@
 Package: velociraptor
 Title: Toolkit for Single-Cell Velocity
 Version: 0.99.0
-Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevin.rue-albrecht@ndlcs.ox.ac.uk", comment = c(ORCID = "0000-0003-3899-3872")),
+Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Aaron", "Lun", role="aut", email="infinite.monkeys.with.keyboards@gmail.com", comment = c(ORCID = '0000-0002-3564-4813')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')))
 Description: Bioconductor-friendly wrappers for RNA velocity calculations in single-cell RNA-seq data.
     The basilisk package is used to manage Conda environments.
+    The zellkonverter package is used to convert data structures between SingleCellExperiment (R) and AnnData (Python).
 Depends:
     SummarizedExperiment
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,9 +4,10 @@ Version: 0.99.0
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Aaron", "Lun", role="aut", email="infinite.monkeys.with.keyboards@gmail.com", comment = c(ORCID = '0000-0002-3564-4813')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')))
-Description: Bioconductor-friendly wrappers for RNA velocity calculations in single-cell RNA-seq data.
-    The basilisk package is used to manage Conda environments.
-    The zellkonverter package is used to convert data structures between SingleCellExperiment (R) and AnnData (Python).
+Description: This package provides Bioconductor-friendly wrappers for RNA velocity calculations in single-cell RNA-seq data.
+    We use the basilisk package to manage Conda environments,
+    and the zellkonverter package to convert data structures between SingleCellExperiment (R) and AnnData (Python).
+    The information produced by the velocity methods is stored in the various components of the SingleCellExperiment class.
 Depends:
     SummarizedExperiment
 Imports:
@@ -39,5 +40,5 @@ Encoding: UTF-8
 RoxygenNote: 7.1.1
 URL: https://github.com/kevinrue/velociraptor
 BugReports: https://github.com/kevinrue/velociraptor/issues
-biocViews: SingleCell, GeneExpression
+biocViews: SingleCell, GeneExpression, Sequencing, Coverage
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# velociraptor 0.99.0
+
+* First submission to Bioconductor.

--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -1,5 +1,5 @@
 # scvelo 0.2.2 and latest version of dependencies in zellkonverter::.AnnDataDependencies succesfully tested.
-.scvelo_depedencies <- c(
+.scvelo_dependencies <- c(
     "scvelo==0.2.2",
     "anndata==0.7.4",
     "h5py==2.10.0",
@@ -14,4 +14,4 @@
 #' @importFrom basilisk BasiliskEnvironment
 #' @importFrom zellkonverter .AnnDataDependencies
 velo.env <- BasiliskEnvironment("env", "velociraptor",
-    packages=.scvelo_depedencies, channels = c("bioconda"))
+    packages=.scvelo_dependencies, channels = c("bioconda", "conda-forge"))

--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -1,4 +1,4 @@
 #' @importFrom basilisk BasiliskEnvironment
 #' @importFrom zellkonverter .AnnDataDependencies
 velo.env <- BasiliskEnvironment("env", "velociraptor",
-    packages=zellkonverter::.AnnDataDependencies, pip="scvelo==0.2.1")
+    packages=zellkonverter::.AnnDataDependencies, pip="scvelo==0.2.2")

--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -1,4 +1,17 @@
+# scvelo 0.2.2 and latest version of dependencies in zellkonverter::.AnnDataDependencies succesfully tested.
+.scvelo_depedencies <- c(
+    "scvelo==0.2.2",
+    "anndata==0.7.4",
+    "h5py==2.10.0",
+    "hdf5==1.10.6",
+    "natsort==7.0.1",
+    "numpy==1.19.1",
+    "packaging==20.4",
+    "pandas==1.1.2",
+    "scipy==1.5.2"
+)
+
 #' @importFrom basilisk BasiliskEnvironment
 #' @importFrom zellkonverter .AnnDataDependencies
 velo.env <- BasiliskEnvironment("env", "velociraptor",
-    packages=zellkonverter::.AnnDataDependencies, pip="scvelo==0.2.1")
+    packages=.scvelo_depedencies, channels = c("bioconda"))

--- a/R/basilisk.R
+++ b/R/basilisk.R
@@ -1,4 +1,4 @@
 #' @importFrom basilisk BasiliskEnvironment
 #' @importFrom zellkonverter .AnnDataDependencies
 velo.env <- BasiliskEnvironment("env", "velociraptor",
-    packages=zellkonverter::.AnnDataDependencies, pip="scvelo==0.2.2")
+    packages=zellkonverter::.AnnDataDependencies, pip="scvelo==0.2.1")

--- a/man/velociraptor-package.Rd
+++ b/man/velociraptor-package.Rd
@@ -7,6 +7,7 @@
 \title{velociraptor: Toolkit for Single-Cell Velocity}
 \description{
 Bioconductor-friendly wrappers for RNA velocity calculations in single-cell RNA-seq data.
+    The basilisk package is used to manage Conda environments.
 }
 \seealso{
 Useful links:

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -112,6 +112,10 @@ velo.out2 <- scvelo(sce, assay.X=1, subset.row=top.hvgs, use.dimred="PCA")
 velo.out2
 ```
 
+```{r, include=FALSE}
+rm(velo.out2)
+```
+
 We also provide an option to use the `r basilisk::PyPiLink("scvelo")` pipeline without modification,
 i.e., relying on their normalization and feature selection.
 This sacrifices consistency with other Bioconductor workflows but enables perfect mimicry of a pure Python-based analysis. 
@@ -122,6 +126,10 @@ velo.out3 <- scvelo(sce, assay.X=1, use.theirs=TRUE)
 velo.out3
 ```
 
+```{r, include=FALSE}
+rm(velo.out3)
+```
+
 Advanced users can tinker with the settings of individual `r basilisk::PyPiLink("scvelo")` steps
 by setting named lists of arguments in the `scvelo.params=` argument.
 For example, to tinker with the behavior of the `recover_dynamics` step, we could do:
@@ -130,6 +138,10 @@ For example, to tinker with the behavior of the `recover_dynamics` step, we coul
 velo.out4 <- scvelo(sce, assay.X=1, subset.row=top.hvgs,
     scvelo.params=list(recover_dynamics=list(max_iter=20)))
 velo.out4
+```
+
+```{r, include=FALSE}
+rm(velo.out4)
 ```
 
 # Session information

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -39,8 +39,9 @@ sce
 
 # Downsampling for demonstration
 
-The full data set requires up to 11 GB of memory for the example usage presented in this vignette.
+The full data set requires up to 12 GB of memory for the example usage presented in this vignette.
 For demonstration purposes, we downsample the data set to the first 500 cells.
+Feel free to skip this downsampling step if you have access to sufficient memory.
 
 ```{r}
 sce <- sce[, 1:500]

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -1,8 +1,8 @@
 ---
 title: Computing RNA velocity in a Bioconductor framework
 author:
-- name: Kevin "the Destroyer" Rue-Albrecht
-- name: Aaron "Cholesterol" Lun
+- name: Kevin Rue-Albrecht
+- name: Aaron Lun
   email: infinite.monkeys.with.keyboards@gmail.com
 - name: Charlotte Soneson
   email: charlottesoneson@gmail.com

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -112,10 +112,6 @@ velo.out2 <- scvelo(sce, assay.X=1, subset.row=top.hvgs, use.dimred="PCA")
 velo.out2
 ```
 
-```{r, include=FALSE}
-rm(velo.out2)
-```
-
 We also provide an option to use the `r basilisk::PyPiLink("scvelo")` pipeline without modification,
 i.e., relying on their normalization and feature selection.
 This sacrifices consistency with other Bioconductor workflows but enables perfect mimicry of a pure Python-based analysis. 
@@ -126,10 +122,6 @@ velo.out3 <- scvelo(sce, assay.X=1, use.theirs=TRUE)
 velo.out3
 ```
 
-```{r, include=FALSE}
-rm(velo.out3)
-```
-
 Advanced users can tinker with the settings of individual `r basilisk::PyPiLink("scvelo")` steps
 by setting named lists of arguments in the `scvelo.params=` argument.
 For example, to tinker with the behavior of the `recover_dynamics` step, we could do:
@@ -138,10 +130,6 @@ For example, to tinker with the behavior of the `recover_dynamics` step, we coul
 velo.out4 <- scvelo(sce, assay.X=1, subset.row=top.hvgs,
     scvelo.params=list(recover_dynamics=list(max_iter=20)))
 velo.out4
-```
-
-```{r, include=FALSE}
-rm(velo.out4)
 ```
 
 # Session information

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -37,6 +37,15 @@ sce <- HermannSpermatogenesisData()
 sce
 ```
 
+# Downsampling for demonstration
+
+The full data set requires up to 11 GB of memory for the example usage presented in this vignette.
+For demonstration purposes, we downsample the data set to the first 500 cells.
+
+```{r}
+sce <- sce[, 1:500]
+```
+
 # Basic workflow
 
 We assume that feature selection has already been performed by the user using any method 


### PR DESCRIPTION
Downsampling is needed to fit within the [7 GB memory limit on the GHA runner](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources)

