### PR TITLE
Remove column names of reduced dimension representation

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -37,9 +37,9 @@ env:
   has_testthat: 'true'
   run_covr: 'true'
   run_pkgdown: 'true'
-  run_docker: 'true'
   has_RUnit: 'false'
   cache-version: 'cache-v1'
+  run_docker: 'true'
 
 jobs:
   build-check:
@@ -52,9 +52,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'devel', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'devel', bioc: 'devel'}
-          - { os: windows-latest, r: 'devel', bioc: 'devel'}
+          - { os: ubuntu-latest, r: 'devel', bioc: '3.15', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - { os: macOS-latest, r: 'devel', bioc: '3.15'}
+          - { os: windows-latest, r: 'devel', bioc: '3.15'}
+          ## Check https://github.com/r-lib/actions/tree/master/examples
+          ## for examples using the http-user-agent
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
@@ -85,6 +87,7 @@ jobs:
         uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
 
       ## pandoc is already included in the Bioconductor docker images
       - name: Setup pandoc from r-lib
@@ -97,7 +100,7 @@ jobs:
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
         shell: Rscript {0}
 
-      - name: Cache R packages
+      - name: Restore R package cache
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os != 'Linux'"
         uses: actions/cache@v2
         with:
@@ -137,6 +140,9 @@ jobs:
           ## For installing usethis's dependency gert
           brew install libgit2
 
+          ## Required for tcltk
+          brew install xquartz --cask
+
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'
         run: |
@@ -151,7 +157,7 @@ jobs:
 
       - name: Set BiocVersion
         run: |
-          BiocManager::install(version = "${{ matrix.config.bioc }}", ask = FALSE)
+          BiocManager::install(version = "${{ matrix.config.bioc }}", ask = FALSE, force = TRUE)
         shell: Rscript {0}
 
       - name: Install dependencies pass 1
@@ -163,22 +169,37 @@ jobs:
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
 
+          ## Set the repos source depending on the OS
+          ## Alternatively use https://storage.googleapis.com/bioconductor_docker/packages/
+          ## though based on https://bit.ly/bioc2021-package-binaries
+          ## the Azure link will be the main one going forward.
+          gha_repos <- if(
+              .Platform$OS.type == "unix" && Sys.info()["sysname"] != "Darwin"
+          ) c(
+              "AnVIL" = "https://bioconductordocker.blob.core.windows.net/packages/3.15/bioc",
+              BiocManager::repositories()
+              ) else BiocManager::repositories()
+
+          ## For running the checks
+          message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
+          install.packages(c("rcmdcheck", "BiocCheck"), repos = gha_repos)
+
           ## Pass #1 at installing dependencies
+          ## This pass uses AnVIL-powered fast binaries
+          ## details at https://github.com/nturaga/bioc2021-bioconductor-binaries
+          ## The speed gains only apply to the docker builds.
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))
-          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
+          remotes::install_local(dependencies = TRUE, repos = gha_repos, build_vignettes = FALSE, upgrade = TRUE)
         continue-on-error: true
         shell: Rscript {0}
 
       - name: Install dependencies pass 2
         run: |
           ## Pass #2 at installing dependencies
+          ## This pass does not use AnVIL and will thus update any packages
+          ## that have seen been updated in Bioconductor
           message(paste('****', Sys.time(), 'pass number 2 at installing dependencies: any remaining dependencies ****'))
-          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
-          
-          ## For running the checks
-          message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
-          remotes::install_cran("rcmdcheck")
-          BiocManager::install("BiocCheck")
+          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE, force = TRUE)
         shell: Rscript {0}
 
       - name: Install BiocGenerics
@@ -189,7 +210,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Install covr
-        if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_cran("covr")
         shell: Rscript {0}
@@ -206,20 +227,17 @@ jobs:
           pkgs <- installed.packages()[, "Package"]
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
-      
-      - name: Find libinfo before creating basilisk environments
-        if: runner.os == 'Linux'
-        run: |
-          find / -name "libtinfo.so*" -ls
 
       - name: Run CMD check
         env:
           _R_CHECK_CRAN_INCOMING_: false
+          DISPLAY: 99.0
         run: |
+          options(crayon.enabled = TRUE)
           rcmdcheck::rcmdcheck(
-              args = c("--no-build-vignettes", "--no-manual", "--timings"),
-              build_args = c("--no-manual", "--no-resave-data"),
-              error_on = "warning",
+              args = c("--no-manual", "--no-vignettes", "--timings"),
+              build_args = c("--no-manual", "--keep-empty-dirs", "--no-resave-data"),
+              error_on = "error",
               check_dir = "check"
           )
         shell: Rscript {0}
@@ -236,6 +254,8 @@ jobs:
         shell: Rscript {0}
 
       - name: Run BiocCheck
+        env:
+          DISPLAY: 99.0
         run: |
           BiocCheck::BiocCheck(
               dir('check', 'tar.gz$', full.names = TRUE),
@@ -246,25 +266,20 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        if: github.ref == 'refs/heads/master' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           covr::codecov()
         shell: Rscript {0}
 
       - name: Install package
-        if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: R CMD INSTALL .
-      
-      - name: Find libinfo before pkgdown
-        if: runner.os == 'Linux'
-        run: |
-          find / -name "libtinfo.so*" -ls
 
-      - name: Deploy package
+      - name: Build and deploy pkgdown site
         if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           Rscript -e "pkgdown::deploy_to_branch(new_process = FALSE)"
         shell: bash {0}
         ## Note that you need to run pkgdown::deploy_to_branch(new_process = FALSE)
@@ -279,11 +294,12 @@ jobs:
           name: ${{ runner.os }}-biocversion-devel-r-devel-results
           path: check
 
-      - name: Push to Docker Hub
-        if: github.ref == 'refs/heads/master' && env.run_docker == 'true' && runner.os == 'Linux'
-        uses: docker/build-push-action@v1
+      - uses: docker/build-push-action@v1
+        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && runner.os == 'Linux' "
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: kevinrue/velociraptor
+          repository: isee/iseeu
           tag_with_ref: true
+          tag_with_sha: true
+          tags: latest

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -299,7 +299,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: isee/iseeu
+          repository: kevinrue/velociraptor
           tag_with_ref: true
           tag_with_sha: true
           tags: latest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: velociraptor
 Title: Toolkit for Single-Cell Velocity
-Version: 1.5.1
-Date: 2021-12-14
+Version: 1.5.2
+Date: 2022-01-27
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Aaron", "Lun", role="aut", email="infinite.monkeys.with.keyboards@gmail.com", comment = c(ORCID = '0000-0002-3564-4813')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# velociraptor 1.5.2
+
+* Remove column names of reduced dimension representation before velocity embedding.
+
 # velociraptor 1.5.1
 
 * Add example for `scvelo.params` argument.

--- a/R/embedVelocity.R
+++ b/R/embedVelocity.R
@@ -40,6 +40,7 @@ NULL
 #' @importFrom SingleCellExperiment reducedDim<-
 .embed_velocity <- function(x, vobj, ...) {
     reducedDim(vobj, "X_target") <- as.matrix(x)
+    colnames(reducedDim(vobj, "X_target")) <- NULL
     basiliskRun(env=velo.env, fun=.run_embedder, vobj=vobj, ...)
 }
 


### PR DESCRIPTION
Remove column names of reduced dimension representation before embedding velocities, to avoid errors like this from the python code: 

```
> emb <- embedVelocity(reducedDim(sce, "PCA"), velo.out)
ℹ Using the 'X' assay as the X matrix
Error in py_call_impl(callable, dots$args, dots$keywords) : 
  KeyError: "None of [Int64Index([496, 475, 470, 439, 410, 393, 390, 387, 382, 365, 364, 362, 359,\n            349, 329, 299, 
297, 285, 264, 259, 207, 206, 187, 186, 182, 175,\n            171, 162, 160, 154, 145, 135, 124, 123, 119, 109, 108, 101,  93,\n         
91,  86,  84,  78,  76,  68,  58,  57,  53,  50,  49,  45,  37,\n             34,  15,  14,   9,   3,   2,   1],\n           dtype='int64')] are in 
the [columns]"
```

Seems to come from [here](https://github.com/theislab/scvelo/blob/1805ab4a72d3f34496f0ef246500a159f619d3a2/scvelo/tools/velocity_embedding.py#L164), and it looks like `X_emb` becomes a pandas data frame if it has column names (in which case the subsequent subsetting doesn't work), and a numpy array otherwise. 
