### PR TITLE
Fix segment plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: velociraptor
 Title: Toolkit for Single-Cell Velocity
-Version: 1.9.1
-Date: 2022-04-19
+Version: 1.9.2
+Date: 2023-04-02
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Aaron", "Lun", role="aut", email="infinite.monkeys.with.keyboards@gmail.com", comment = c(ORCID = '0000-0002-3564-4813')),
     person("Charlotte", "Soneson", role="aut", email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# velociraptor 1.9.2
+
+* Remove column names from reduced dimension matrix in `gridVectors()`.
+
 # velociraptor 1.5.2
 
 * Remove column names of reduced dimension representation before velocity embedding.

--- a/R/gridVectors.R
+++ b/R/gridVectors.R
@@ -104,5 +104,7 @@ setMethod("gridVectors", "ANY", .grid_vectors)
 #' @export
 #' @rdname gridVectors
 setMethod("gridVectors", "SingleCellExperiment", function(x, embedded, ..., use.dimred=1) {
-    .grid_vectors(reducedDim(x, use.dimred), embedded, ...)
+    dimred <- reducedDim(x, use.dimred)
+    colnames(dimred) <- NULL
+    .grid_vectors(dimred, embedded, ...)
 })

--- a/vignettes/velociraptor.Rmd
+++ b/vignettes/velociraptor.Rmd
@@ -100,7 +100,7 @@ This uses a grid-based approach to summarize the per-cell vectors into local rep
 
 ```{r}
 embedded <- embedVelocity(reducedDim(sce, "TSNE"), velo.out)
-grid.df <- gridVectors(reducedDim(sce, "TSNE"), embedded)
+grid.df <- gridVectors(sce, embedded, use.dimred = "TSNE")
 
 library(ggplot2)
 plotTSNE(sce, colour_by="velocity_pseudotime") +


### PR DESCRIPTION
An attempt to fix the current error on the Bioc devel builders. `scater` now consistently sets column names on reduced dimension matrices, which meant that in our vignette, there were no columns `start.1`, ... in the output of `gridVectors()` (but rather `start.TSNE1`, ...). Since we already remove the column names from reduced dimension matrices in `embedVelocity()`, I did the same when `gridVectors()` is applied to a SCE object. I guess the alternative would be to keep the column names (since this should now be consistent across all dimension reduction methods) and adapt the column names in the plot accordingly. Thoughts? 