### PR TITLE
Robust fallback mechanism

### DIFF
--- a/R/scvelo.R
+++ b/R/scvelo.R
@@ -108,7 +108,7 @@
 #' containing the velocity vectors for each cell.
 #' }
 #' The output will always have number of columns equal to the number of cells supplied in \code{x},
-#' though the number of rows will depend on whether any subsetting (if \code{subset.row} is supplied) 
+#' though the number of rows will depend on whether any subsetting (if \code{subset.row} is supplied)
 #' or feature selection (if \code{use.theirs=TRUE}) was performed.
 #'
 #' @examples
@@ -123,8 +123,8 @@
 #' out <- scvelo(list(X=spliced, spliced=spliced, unspliced=unspliced))
 #'
 #' # make scvelo use 10 rather than the default 30 neighbors to compute moments for velocity estimation:
-#' out <- scvelo(list(X=spliced, spliced=spliced, unspliced=unspliced), 
-#'               scvelo.params=list(moments=list(n_neighbors=10L))) 
+#' out <- scvelo(list(X=spliced, spliced=spliced, unspliced=unspliced),
+#'               scvelo.params=list(moments=list(n_neighbors=10L)))
 #'
 #' @references
 #' Bergen, V., Lange, M., Peidli, S. et al. Generalizing RNA velocity to transient cell states through dynamical modeling. Nat Biotechnol 38, 1408–1414 (2020). \url{https://doi.org/10.1038/s41587-020-0591-3}
@@ -175,7 +175,7 @@ NULL
         X=X, spliced=spliced, unspliced=unspliced,
         use.theirs=use.theirs, mode=mode,
         scvelo.params=scvelo.params,
-        dimred=dimred)
+        dimred=dimred, testload = c("scvelo", "anndata"))
 
     output
 }

--- a/R/scvelo.R
+++ b/R/scvelo.R
@@ -180,23 +180,20 @@ NULL
     output
 }
 
-#' @importFrom reticulate import
-#' @importFrom DelayedArray is_sparse t
-#' @importFrom zellkonverter AnnData2SCE
 .run_scvelo <- function(X, spliced, unspliced, use.theirs=FALSE, mode='dynamical', scvelo.params=list(), dimred=NULL) {
-    X <- t(.make_np_friendly(X))
-    spliced <- t(.make_np_friendly(spliced))
-    unspliced <- t(.make_np_friendly(unspliced))
+    X <- t(velociraptor:::.make_np_friendly(X))
+    spliced <- t(velociraptor:::.make_np_friendly(spliced))
+    unspliced <- t(velociraptor:::.make_np_friendly(unspliced))
 
-    and <- import("anndata")
-    scv <- import("scvelo")
+    and <- reticulate::import("anndata")
+    scv <- reticulate::import("scvelo")
     adata <- and$AnnData(X, layers=list(spliced=spliced, unspliced=unspliced))
     adata$obs_names <- rownames(spliced)
     adata$var_names <- colnames(spliced)
 
     ## A supplied dimred will be used even if use.theirs=TRUE
     if (!is.null(dimred)) {
-        dimred <- .make_np_friendly(dimred)
+        dimred <- velociraptor:::.make_np_friendly(dimred)
         adata$obsm <- list(X_pca = dimred)
     }
 
@@ -223,7 +220,7 @@ NULL
 
     do.call(scv$tl$velocity_confidence, c(list(data=adata), scvelo.params$velocity_confidence))
 
-    AnnData2SCE(adata)
+    zellkonverter::AnnData2SCE(adata)
 }
 
 #' @export


### PR DESCRIPTION
We had some issues running `velociraptor::scvelo` at my workplace 

```
ImportError: /lib64/libz.so.1: version `ZLIB_1.2.9' not found (required by <USER DIRECTORY>/.cache/R/basilisk/1.14.0/velociraptor/1.12.0/env/lib/python3.8/site-packages/matplotlib/../../.././libpng16.so.16)
```

I think the issue is that the R process links to our built-in system zlib (`/lib64/libz.so.1`) which takes precedence over the newer version that is installed into the conda environment (and it does get installed, I checked). Then when reticulate runs Python inside the same process it also uses the old zlib version.

There might be a more elegant solution, but I found a neat workaround to this issue that follows advice in the `basilisk` manual. Basically we set the `testload` packages so basilisk can check if there's a linking error, and if there is an error then basilisk creates a fallback environment that contains its own version of R and runs the `.run_scvelo` function there instead.  I namespace (`::`) every function call inside the basilisk function so that they will still work the fallback R interpreter which has no packages loaded by default. What's nice about this solution is that it changes absolutely nothing for users who didn't encounter this issue, but it fixes it for those who did. The only thing I don't like is having to use `:::` to access internal functions inside the `velociraptor` package, since it won't be available by default in the fallback env, but I can't think of a better solution.

The modified version of this package has been checked by myself and another researcher and it seems to work fine.